### PR TITLE
[v2.x] Improve tests and skip Python 3.12

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 ldas_tools_framecpp:
@@ -27,7 +27,6 @@ numpy:
 - '2.0'
 - '2.0'
 - '1.22'
-- '1.22'
 - '2.0'
 pin_run_as_build:
   python:
@@ -37,11 +36,9 @@ python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
 - 3.12.* *_cpython
-- 3.8.* *_cpython
 - 3.9.* *_73_pypy
 - 3.9.* *_cpython
 python_impl:
-- cpython
 - cpython
 - cpython
 - cpython

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -19,7 +19,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 ldas_tools_framecpp:
@@ -31,7 +31,6 @@ numpy:
 - '2.0'
 - '2.0'
 - '1.22'
-- '1.22'
 - '2.0'
 pin_run_as_build:
   python:
@@ -41,11 +40,9 @@ python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
 - 3.12.* *_cpython
-- 3.8.* *_cpython
 - 3.9.* *_73_pypy
 - 3.9.* *_cpython
 python_impl:
-- cpython
 - cpython
 - cpython
 - cpython

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 ldas_tools_framecpp:
@@ -27,7 +27,6 @@ numpy:
 - '2.0'
 - '2.0'
 - '1.22'
-- '1.22'
 - '2.0'
 pin_run_as_build:
   python:
@@ -37,11 +36,9 @@ python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
 - 3.12.* *_cpython
-- 3.8.* *_cpython
 - 3.9.* *_73_pypy
 - 3.9.* *_cpython
 python_impl:
-- cpython
 - cpython
 - cpython
 - cpython

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '16'
+- '17'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '16'
+- '17'
 ldas_tools_framecpp:
 - '2.9'
 libboost_devel:
@@ -29,7 +29,6 @@ numpy:
 - '2.0'
 - '2.0'
 - '1.22'
-- '1.22'
 - '2.0'
 pin_run_as_build:
   python:
@@ -39,11 +38,9 @@ python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
 - 3.12.* *_cpython
-- 3.8.* *_cpython
 - 3.9.* *_73_pypy
 - 3.9.* *_cpython
 python_impl:
-- cpython
 - cpython
 - cpython
 - cpython

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '16'
+- '17'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '16'
+- '17'
 ldas_tools_framecpp:
 - '2.9'
 libboost_devel:
@@ -28,7 +28,6 @@ numpy:
 - '2.0'
 - '2.0'
 - '2.0'
-- '1.22'
 - '2.0'
 pin_run_as_build:
   python:
@@ -38,10 +37,8 @@ python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
 - 3.12.* *_cpython
-- 3.8.* *_cpython
 - 3.9.* *_cpython
 python_impl:
-- cpython
 - cpython
 - cpython
 - cpython

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -11,7 +11,4 @@ conda_forge_output_validation: true
 github:
   branch_name: main
   tooling_branch_name: main
-provider:
-  linux_aarch64: azure
-  linux_ppc64le: azure
 test: native_and_emulated

--- a/recipe/build-python.sh
+++ b/recipe/build-python.sh
@@ -25,5 +25,12 @@ fi
 # build
 cmake --build python --parallel ${CPU_COUNT} --verbose
 
+# test
+if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" ]]; then
+	# copy test frames from main build
+	cp -rv ${SRC_DIR}/_build/frames .
+	ctest --parallel ${CPU_COUNT} --verbose
+fi
+
 # install
 cmake --build python --parallel ${CPU_COUNT} --verbose --target install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ outputs:
     script: build-python.sh
     build:
       error_overlinking: true
-      skip: true  # [python_impl != 'cpython']
+      skip: true  # [python_impl != 'cpython' or py>=312]
     requirements:
       build:
         - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
 
 build:
   error_overlinking: true
-  number: 4
+  number: 5
   skip: true  # [win]
 
 requirements:

--- a/recipe/test_ldas_tools_framecpp.py
+++ b/recipe/test_ldas_tools_framecpp.py
@@ -4,6 +4,8 @@
 import os
 import subprocess
 
+import numpy
+
 import pytest
 
 from LDAStools import frameCPP
@@ -35,6 +37,15 @@ def test_gettoc(sample_data):
         "Z0:RAMPED_REAL_4_1",
         "Z0:RAMPED_REAL_8_1",
     ])
+
+
+def test_getdataarray(sample_data):
+    stream = frameCPP.IFrameFStream(str(sample_data))
+    frdata = stream.ReadFrAdcData(0, "Z0:RAMPED_REAL_4_1")
+    for i in range(frdata.data.size()):
+        vect = frdata.data[i]
+        arr = vect.GetDataArray()
+        assert arr.dtype == numpy.float32
 
 
 def test_readfradcdata(sample_data):


### PR DESCRIPTION
This PR closes https://github.com/conda-forge/ldas-tools-framecpp-swig-feedstock/issues/32 by improving the tests of the Python package in this recipe, and then skipping Python 3.12 builds. The skip can be reverted whenever the upstream issue (https://git.ligo.org/computing/ldastools/LDAS_Tools/-/issues/224) is understood and resolved (or patched).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
